### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fluent-plugin-pgsql_fingerprint (0.0.2)
+    fluent-plugin-pgsql_fingerprint (0.1.0)
       fluentd (~> 1.14)
       pg_query (~> 1.3)
 

--- a/fluent-plugin-pgsql_fingerprint.gemspec
+++ b/fluent-plugin-pgsql_fingerprint.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'fluent-plugin-pgsql_fingerprint'
-  spec.version = '0.0.2'
+  spec.version = '0.1.0'
   spec.authors = ['Daisuke Hirakiuchi']
   spec.email = ['hirakiuc@gmail.com']
 
   spec.summary = "A Fluent filter plugin to convert postgres sql to sql's fingerprint"
-  spec.description = "A Fluent filter plugin to convert postgres sql to sql's fingerprint. (for fluentd v0.14)"
+  spec.description = "A Fluent filter plugin to convert postgres sql to sql's fingerprint. (for fluentd v1.14)"
   spec.homepage = "https://github.com/hirakiuc/fluent-plugin-pgsql_fingerprint"
   spec.license = "MIT"
 


### PR DESCRIPTION
# WHAT

- Bump version to `v0.1.0` .

# WHY

- For the security reasons, I needed to update so many dependencies.

---

Since I don't have any environment where I can test this plugin, I'll not release this version to rubygems.org 🙇🏼‍♂️ 
If someone want to use the new version, please build this by yourself. 🙏🏼 